### PR TITLE
Fixed TypeError: removed unsupported argument ApiDebugLevel

### DIFF
--- a/examples/SkypeBot.py
+++ b/examples/SkypeBot.py
@@ -6,7 +6,7 @@ import re
 
 class SkypeBot(object):
   def __init__(self):
-    self.skype = Skype4Py.Skype(Events=self, ApiDebugLevel=1)
+    self.skype = Skype4Py.Skype(Events=self)
     self.skype.FriendlyName = "Skype Bot"
     self.skype.Attach()
     


### PR DESCRIPTION
TypeError appears when running SkypeBot.py.

Probably this is about change which logged in the `./doc/old-changelog.txt` changelog:

2009-05-25  awahlig                                                                                                                                                 ▸     Skype.ApiDebugLevel property removed.
