### PR TITLE
Add requirements to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -134,6 +134,10 @@ commands = {'build_doc': build_doc,
 
 desc = open("README.rst").read() + "\n" + open("CHANGES.rst").read()
 
+system_specific_deps = {
+        'posix': ['dbus', 'gobject'],
+        }
+
 # start the distutils setup
 setup(name='Skype4Py',
       version=VERSION,
@@ -148,6 +152,6 @@ setup(name='Skype4Py',
       packages=['Skype4Py', 'Skype4Py.api', 'Skype4Py.lang'],
       provides=['Skype4Py'],
       install_requires=['setuptools'],
-      requires=['dbus', 'gobject'],
+      requires=system_specific_requires.get(os.name, []),
       zip_safe=True,
       cmdclass=commands)

--- a/setup.py
+++ b/setup.py
@@ -148,5 +148,6 @@ setup(name='Skype4Py',
       packages=['Skype4Py', 'Skype4Py.api', 'Skype4Py.lang'],
       provides=['Skype4Py'],
       install_requires=['setuptools'],
+      requires=['dbus', 'gobject'],
       zip_safe=True,
       cmdclass=commands)

--- a/setup.py
+++ b/setup.py
@@ -134,7 +134,7 @@ commands = {'build_doc': build_doc,
 
 desc = open("README.rst").read() + "\n" + open("CHANGES.rst").read()
 
-system_specific_deps = {
+system_specific_requires = {
         'posix': ['dbus', 'gobject'],
         }
 


### PR DESCRIPTION
Skype4Py requires `python-dbus` and `python-gobject` to work, but they are not mentionned in the setup.py metadata.