### PR TITLE
fix error in CFString __str__ method preventing api from working

### DIFF
--- a/Skype4Py/api/darwin.py
+++ b/Skype4Py/api/darwin.py
@@ -105,7 +105,7 @@ class CFString(CFType):
         if coref.CFStringGetBytes(self, 0, i, 0x08000100, 0, False, None, 0, byref(size)) > 0:
             buf = create_string_buffer(size.value)
             coref.CFStringGetBytes(self, 0, i, 0x08000100, 0, False, buf, size, None)
-            return buf.value
+            return buf.value.decode("utf-8")
         else:
             raise UnicodeError('CFStringGetBytes() failed')
 


### PR DESCRIPTION
This fixes a bug in os x where the Attach() would fail with the following error:

  File "/Users/briantanner/GitRepos/Skype4Py/Skype4Py/api/darwin.py", line 418, in init_observer
    self.center.add_observer(self.observer, self.SKSkypeAPINotification, 'SKSkypeAPINotification', immediate=True)
  File "/Users/briantanner/GitRepos/Skype4Py/Skype4Py/api/darwin.py", line 209, in add_observer
    self.callbacks[(str(observer), str(name))] = callback
TypeError: **str** returned non-string (type bytes)
